### PR TITLE
Add a prelude, re-export PAC, UART updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
+pub use esp8266 as target;
+
 pub mod gpio;
+pub mod prelude;
 pub mod timer;
 pub mod uart;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,6 +8,8 @@
 //! This can be imported as use `esp8266_hal::prelude::*`.
 
 pub use crate::gpio::GpioExt;
+pub use crate::timer::TimerExt;
+pub use crate::uart::{UART0Ext, UART1Ext};
 
 pub use embedded_hal::digital::v2::InputPin as _;
 pub use embedded_hal::digital::v2::OutputPin as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,17 @@
+//! The prelude.
+//!
+//! To use `esp8266_hal` effectively, a number of traits and types need to be
+//! imported. Instead of importing them one by one manually, the prelude
+//! contains the most commonly used imports that are used around application
+//! runtime management.
+//!
+//! This can be imported as use `esp8266_hal::prelude::*`.
+
+pub use crate::gpio::GpioExt;
+
+pub use embedded_hal::digital::v2::InputPin as _;
+pub use embedded_hal::digital::v2::OutputPin as _;
+pub use embedded_hal::digital::v2::StatefulOutputPin as _;
+pub use embedded_hal::digital::v2::ToggleableOutputPin as _;
+pub use embedded_hal::prelude::*;
+pub use embedded_hal::timer::{Cancel, CountDown, Periodic};


### PR DESCRIPTION
Just a quick little addition, mostly for convenience. `esp32-hal` uses `target` for the PAC so I've chosen the same alias just to be consistent. I've also added some basic docstrings for the UART module, and implemented `core::fmt::Write` for both `UART0` and `UART1`. I did some basic testing on hardware and things seem to be working properly.