### PR TITLE
Add "rt" feature which re-exports the entry macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,15 @@ repository = "https://github.com/esp-rs/esp8266-hal"
 readme = "README.md"
 
 [dependencies]
+embedded-hal = { version = "0.2.4", features = ["unproven"] }
 esp8266 = "0.1.1"
-nb = "0.1.2"
+nb = "0.1.3"
 void = { version = "1.0.2", default-features = false }
-xtensa-lx106-rt = "0.1.0"
+xtensa-lx106-rt = { version = "0.1.0", optional = true }
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
+[features]
+default = ["rt"]
+rt = ["xtensa-lx106-rt"]
 
 [profile.dev]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 pub use embedded_hal as ehal;
 pub use esp8266 as target;
 
+#[cfg(feature = "rt")]
+pub use xtensa_lx106_rt::entry;
+
 pub mod gpio;
 pub mod prelude;
 pub mod rng;


### PR DESCRIPTION
Just a little one, title should be pretty self-explanatory. This is fairly common in other HALs, and is just one less dependency the user needs to worry about.

I also updated some of the other dependencies while I was in here, but there were just patch version bumps.