### PR TITLE
Add initial support for Gpio16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
-esp8266 = "0.1.1"
+esp8266 = "0.1.2"
 nb = "0.1.3"
 void = { version = "1.0.2", default-features = false }
 xtensa-lx106-rt = { version = "0.1.1", optional = true }


### PR DESCRIPTION
`Gpio16` is controlled by the `RTC` instead of the `IOMUX`; This PR adds support for using this pin. I'm not sure it's 100% correct at this point, but it seems to be functioning correctly based on the limited testing I've performed so far.