### PR TITLE
Fix for compiler build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An example project using the crate can be found [here](https://github.com/icewin
 ```
 $ git clone https://github.com/MabezDev/rust-xtensa
 $ cd rust-xtensa
-$ ./configure --experimental-targets=Xtens
+$ ./configure --experimental-targets=Xtensa
 $ ./x.py build
 ```
 


### PR DESCRIPTION
Fixes the following error that occurs during the build process:

```
CMake Error at CMakeLists.txt:713 (message):
  Unexpected failure executing llvm-build: Usage: llvm-build [options]

  

  llvm-build: error: invalid target to enable: 'Xtens' (not in project)
```