### PR TITLE
Don't include xtensa_lx_rt in prelude if rt is disabled

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,6 +18,7 @@ pub use crate::timer::TimerExt;
 pub use crate::uart::{UART0Ext, UART1Ext};
 pub use crate::watchdog::WatchdogExt;
 pub use esp8266_hal_proc_macros::{interrupt, ram};
+#[cfg(feature = "rt")]
 pub use xtensa_lx_rt::{entry, exception};
 
 pub use embedded_hal::digital::v2::InputPin as _;


### PR DESCRIPTION
With the `rt` feature disabled, the crate failed to build - `xtensa-lx-rt` is optional and not included as a dependency if `rt` is off.

Make the problematic line in prelude depend on the rt feature.